### PR TITLE
Bump to Play 2.5 and add adapater command for Future

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -1,10 +1,12 @@
 package controllers
 
 import play.api.mvc._
+import akka.actor.ActorSystem
 import commands.{HelloWorld, HelloWorldAsync}
 import util.Futures
+import javax.inject.Inject
 
-object Application extends Controller {
+class Application @Inject()(implicit system: ActorSystem) extends Controller {
   import play.api.libs.concurrent.Execution.Implicits.defaultContext
 
 import util.Futures._

--- a/build.sbt
+++ b/build.sbt
@@ -2,13 +2,13 @@ name := "hystrix-play"
 
 version := "1.0-SNAPSHOT"
 
-scalaVersion := "2.10.4"
+scalaVersion := "2.11.8"
+
+lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
 libraryDependencies ++= Seq(
-  "com.netflix.archaius" % "archaius-scala" % "0.4.1",
-  "com.netflix.hystrix" % "hystrix-core" % "1.4.0-RC4",
-  "com.netflix.hystrix" % "hystrix-metrics-event-stream" % "1.4.0-RC4",
+  "com.netflix.archaius" % "archaius-scala" % "0.7.4",
+  "com.netflix.hystrix" % "hystrix-core" % "1.5.3",
+  "com.netflix.hystrix" % "hystrix-metrics-event-stream" % "1.5.3",
   "com.netflix.rxjava"  % "rxjava-scala" % "0.18.2"
 )
-
-play.Project.playScalaSettings

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.11

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,8 @@
 // Comment to get more information during initialization
 logLevel := Level.Warn
 
-// The Typesafe repository 
+// The Typesafe repository
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.2.3")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.3")


### PR DESCRIPTION
This request contains 2 improvements below:

- Bump to Play 2.5
- Add `HystrixFutureCommand` which is adapt `scala.concurrent.Future` for the Hystrix command.