### PR TITLE
Hystrix 1.5.6 Update

### DIFF
--- a/app/commands/HelloWorldAsync.scala
+++ b/app/commands/HelloWorldAsync.scala
@@ -25,7 +25,7 @@ class HelloWorldAsync(name: String)(implicit system: ActorSystem, ec: ExecutionC
   }
 
   override protected def resumeWithFallback(): Observable[String] = {
-    Observable.from(Array("Fallback (Async)"))
+    Observable.just("Fallback (Async)")
   }
 
 }

--- a/build.sbt
+++ b/build.sbt
@@ -7,8 +7,10 @@ scalaVersion := "2.11.8"
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
 libraryDependencies ++= Seq(
-  "com.netflix.archaius" % "archaius-scala" % "0.7.4",
-  "com.netflix.hystrix" % "hystrix-core" % "1.5.3",
-  "com.netflix.hystrix" % "hystrix-metrics-event-stream" % "1.5.3",
-  "com.netflix.rxjava"  % "rxjava-scala" % "0.18.2"
+  "com.netflix.archaius" % "archaius-scala" % "0.7.5",
+  "com.netflix.hystrix" % "hystrix-core" % "1.5.6",
+  "com.netflix.hystrix" % "hystrix-metrics-event-stream" % "1.5.6",
+  "io.reactivex" % "rxscala_2.11" % "0.26.3",
+  "io.reactivex" % "rxjava" % "1.2.1",
+  "io.reactivex" % "rxjava-reactive-streams" % "1.2.0"
 )


### PR DESCRIPTION
Updated HystrixSupport to use the new Api for accesing Hystrix Metrics(HystrixMetricsPoller is deprecated since 1.5.4)
Also, added a handler to release connections when an event stream is finished(the client closes the connection)